### PR TITLE
Add missing `matplotlib` import and remove item from `Exercise 0` that only applies to napari dev installation

### DIFF
--- a/docs/day2/02_segmentation_and_measuring.ipynb
+++ b/docs/day2/02_segmentation_and_measuring.ipynb
@@ -52,6 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "from scipy import ndimage as ndi\n",
     "\n",
@@ -141,7 +142,6 @@
     "\n",
     "- zoom with scroll, pan with click and drag\n",
     "- try clicking on the 👁️ icon on each layer in the layer list to make them invisible or visible again\n",
-    "- try alt-clicking on the icon: this makes every other layer invisible\n",
     "- try changing the opacity, colormap, or interpolation on a layer\n",
     "- try turning on \"grid mode\", from the group of buttons at the bottom-left of the viewer.\n",
     "- *select* the labels layer, click on the paintbrush tool, and tweak the segmentation where the two labels meet."


### PR DESCRIPTION
Hi, I was checking the material for day two and seems like a couple of changes/fixes could be done to the [`02_segmentation_and_measuring` notebook](https://github.com/LIBREhub/napari-LatAm-workshop-2023/blob/main/docs/day2/02_segmentation_and_measuring.ipynb):

* Add `matplotlib` import.
* Remove one of the bullet points from `Exercise 0` since the feature `alt-clicking on the visibility icon` (to hide the other layers) is only available when installing from source (is not available with napari 0.4.18 as far as I know).

Not totally sure if the changes done here are actually required @jni but opening a PR just in case :)


